### PR TITLE
Include support for arbitrary output file in relion_star_downgrade.py

### DIFF
--- a/dynamo2m/relion_star_downgrade.py
+++ b/dynamo2m/relion_star_downgrade.py
@@ -5,7 +5,7 @@ import pandas as pd
 import starfile
 
 
-def relion_star_downgrade(star_file):
+def relion_star_downgrade(star_file, output_star_file):
     """Downgrade RELION 3.1 STAR file to RELION 3.0 format for Warp
     """
     star = starfile.read(star_file)
@@ -40,10 +40,16 @@ def relion_star_downgrade(star_file):
     for idx in range(3):
         df[euler_headings[idx]] = eulers[:, idx]
 
-    # Derive output filename
-    star_file = Path(star_file)
-    stem = star_file.stem
-    output_filename = star_file.parent / (str(stem) + '_rln3.0.star')
+    if output_star_file is None:
+
+        # Derive output filename
+        star_file = Path(star_file)
+        stem = star_file.stem
+        output_filename = star_file.parent / (str(stem) + '_rln3.0.star')
+
+    else:
+
+        output_filename = output_star_file
 
     # Write output
     starfile.write(df, output_filename, overwrite=True)
@@ -52,8 +58,14 @@ def relion_star_downgrade(star_file):
 
 
 @click.command()
-@click.option('--star_file', '-s', prompt='Input STAR file')
-def cli(star_file):
-    """Downgrade RELION 3.1 STAR file to RELION 3.0 format for Warp
-    """
-    relion_star_downgrade(star_file)
+@click.option('--star_file', '-s', type=click.Path(exists=True), default=None, help='Input STAR file')
+@click.option('--output_star_file', '-o', type=click.Path(), default=None, help='Output STAR file')
+def cli(star_file, output_star_file):
+    if star_file is None:
+        star_file = click.prompt('Input STAR file', type=click.Path(exists=True))
+
+        if output_star_file is None:
+            output_star_file = click.prompt('Output STAR file', type=click.Path())
+
+    relion_star_downgrade(star_file, output_star_file)
+


### PR DESCRIPTION
Added an optional `--output_star_file,-o` option to `relion_star_downgrade.py` so that the user can write the output with an arbitrary file name.
In interactive mode, the option is only prompted for if no command line options are given to the program.